### PR TITLE
RepoSlug can be optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,12 @@ module.exports = function Log({logsDb, accountId, repoSlug, context}) {
     let date = new Date()
     const shortDate = date.toISOString().replace(/[-,:]/g,'').replace('T', '-').split('.')[0]
     const randomString = Math.ceil(Math.random(1)*1000000)
+    const repoSlugIfExists = repoSlug ? repoSlug + ':' : ''
+
     logsDb.put({
-      _id: `${accountId}:${repoSlug}:${type}:${context}:${shortDate}:${randomString}`,
+      _id: `${accountId}:${repoSlugIfExists}${type}:${context}:${shortDate}:${randomString}`,
       accountId,
-      repoSlug: repoSlug.toLowerCase(),
+      repoSlug: repoSlug ? repoSlug.toLowerCase() : '',
       context,
       type,
       message,

--- a/test.js
+++ b/test.js
@@ -60,3 +60,32 @@ const test4Db = {
 
 const logger4 = Log({logsDb: test4Db, accountId, repoSlug: 'TestOrg/TestRepo', context})
 logger4.info()
+
+// logger is initialized with a repoSlug
+const test5Db = {
+  put: async (a) => {
+    const expectedIdPartial = '123test:testorg/testrepo:info:running-the-tests:'
+    assert.ok(a._id.match(expectedIdPartial), 'correct id found')
+    assert.equal(a.accountId, accountId, 'correct accountId found')
+    assert.equal(a.repoSlug, repoSlug, 'correct repoSlug found')
+    assert.equal(a.context, context, 'correct context found')
+    assert.equal(a.type, 'info', 'correct type found')
+  }
+}
+
+const logger5 = Log({logsDb: test5Db, repoSlug, accountId, context})
+logger5.info('test')
+
+// logger is initialized without a repoSlug
+const test6Db = {
+  put: async (a) => {
+    const expectedIdPartial = '123test:info:running-the-tests:'
+    assert.ok(a._id.match(expectedIdPartial), 'correct id found')
+    assert.equal(a.accountId, accountId, 'correct accountId found')
+    assert.equal(a.context, context, 'correct context found')
+    assert.equal(a.type, 'info', 'correct type found')
+  }
+}
+
+const logger6 = Log({logsDb: test6Db, accountId, context})
+logger6.info('test')


### PR DESCRIPTION
The problem is that some jobs (& other things we want to add logging to) are not associated with a specific repository. 

When looking through `lib/worker.js` I noticed that all jobs have an accountId but not all have the repoSlug. 